### PR TITLE
only try to get current_users id if there is a current user.

### DIFF
--- a/app/views/postings/index.html.erb
+++ b/app/views/postings/index.html.erb
@@ -12,7 +12,7 @@
             <td class="list-table-element description-column"><%= posting.description %></td>
             <td class="list-table-element"><%= posting.available_dates %></td>
             <td class="list-table-element"><%= link_to 'Show', posting %>
-            <% if current_user[:id] == posting.user_id %>
+            <% if current_user && current_user[:id] == posting.user_id %>
               | <%= link_to 'Edit', edit_posting_path(posting) %> |
               <%= link_to 'Destroy', posting, method: :delete, data: { confirm: 'Are you sure?' } %>
             <% end %>


### PR DESCRIPTION
 Fixes inability to search when not logged in that I noticed.
